### PR TITLE
(MAINT) Initial implementation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text eol=lf
+*.png binary

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+resources/_gen
+public

--- a/README.md
+++ b/README.md
@@ -1,2 +1,139 @@
 # hugo-toroidal
+
 Tooling for hosting your own webring using a hugo site/repo as the source of truth/host.
+Inspired by [TooManyBees/ring](https://toomanybees.github.io/ring/about).
+
+## Installing Toroidal to Your Hugo Site
+
+This is a hugo module.
+You'll need to [make sure your site is ready to add this module to it](https://gohugo.io/hugo-modules/use-modules/).
+
+Once that is done, you can update your site config to reference it:
+
+```yaml
+#config.yaml
+module:
+  imports:
+    - path: 'github.com/platenio/hugo-toroidal'
+```
+
+```toml
+#config.toml
+[module]
+[[module.imports]]
+  path = 'github.com/platenio/hugo-toroidal'
+```
+
+Once you've saved your updated config file, you can run `hugo mod get -u` to pull this module down for use.
+
+### Start From Template
+
+Top of our todo list is to set up an extremely minimal default site for you to use which is ready to go.
+We'll update this section when that's ready!
+
+## Configuring Your Webring
+
+Right now there's only one configuration item for this module and it's optional.
+
+If you'd like to name your Webring, edit your site config:
+
+```yaml
+#config.yaml
+params:
+  Toroidal:
+    WebringName: 'FooBar'
+```
+
+```toml
+#config.toml
+[params]
+  [params.Toroidal]
+  WebringName = "FooBar"
+```
+
+The above example will change the header for your site member list to `Members of the FooBar Webring` and the generated webring navigation label to `FooBar Webring`.
+
+If left unset, the header for your site member list will read `Members of the Webring` and the generated webring navigation label will read `Webring`.
+
+## Adding Members
+
+You can add new member sites to your webring by adding a markdown file in your `content/toroidal` folder.
+The only thing you need to include in that file is some frontmatter to tell hugo about the site.
+For example:
+
+```yaml
+# content/toroidal/first-member.md
+---
+name: First Member
+homepage: https://firstmember.com
+description: The first member's site
+weight: 1
+---
+```
+
+This will:
+
+- Set the display name of the site in the member list to `First Member`
+- Set all links to that site (on the member list and in the generated webring navigation) to `https://firstmember.com`
+- Set the short description of the site in the member list to `The first member's site`
+- Set their member number to 1; this is used both to display the members in the correct order in the member list and to determine which sites are considered "previous" and "next" in the generated webring navigation.
+
+You will need a file for every member site added to the webring.
+For now, we don't have any helpers to ease this, but we're going to write some tooling and update this doc as those land.
+
+## Adding the Webring Navigation to Your Member Site
+
+To add the webring navigation to your member site, you'll need to:
+
+1. Have your member page added to the webring host site and live on the internet.
+2. Know the name of the file added (we suggest using your site name lowercased with hyphens instead of spaces; so "My Really Neat Site" would become `my-really-neat-site`)
+3. Add an iframe to your site where you want the navigation to go:
+   ```html
+   <iframe src="https://superneatwebring.com/toroidal/my-really-neat-site">
+   </iframe>
+   ```
+
+That will add the navigation menu wherever you placed it in your own site code.
+If you inspect the iframe, you'll see HTML like this:
+
+```html
+<nav aria-labelledby="toroidal-menu-label">
+  <h2 id="toroidal-menu-label">Super Neat Webring</h2>
+  <ul role="menu" id="toroidal-menu" aria-label="Super Neat Webring">
+    <li role="none">
+      <a role="menuitem" aria-haspopup="false" href="https://previous-member.com">Previous</a>
+    </li>
+    <li role="none">
+      <a role="menuitem" aria-haspopup="false" href="http://superneatwebring.com/toroidal/">Member List</a>
+    </li>
+    <li role="none">
+      <a role="menuitem" aria-haspopup="false" href="https://next-member.com">Next</a>
+    </li>
+  </ul>
+</nav>
+```
+
+> Of course, the URLs and webring name will match your webring!
+
+### Theming
+
+By default, this module does _zero_ special theming for either the member site list or the generated webring navigation menu.
+Your member site list will inherit your hugo theme's defaults and display a paginated list of sites (10 per page, and users can click through the list to see more members if needed).
+
+Your webring navigation will be pure unstyled HTML in an iframe.
+
+Some default themes will be available in the future.
+For now, here's some info you can use to theme things for yourself:
+
+1. The member list is inside of an `article` tag with the `toroidal` class.
+   1. It includes an `h2` tag with the text "Members of the `Webring Name` Webring"
+   2. It includes a `ul` tag with the `toroidal-member-list` class
+   3. Each of the member sites in that list are in a `li` tag with the `toroidal-member-entry` class
+   4. Each `li` includes an `a` tag with their site name and referencing their URL followed by a `span` for their description
+2. The generated webring navigation is inside of a `nav` tag with the `toroidal` class
+   1. The `h2` that labels the navigation has the id `toroidal-menu`
+   2. Each entry in the menu is an `li` tag with role set to `none` with an `a` tag whose role is set to `menuitem`
+
+## Contacting Us
+
+If you have any questions, comments, or concerns, you can reach out to us by [starting a discussion](https://github.com/platenio/hugo-toroidal/discussions/new), [filing an issue](https://github.com/platenio/hugo-toroidal/issues/new), or reaching out to the maintainers on Twitter or Discord.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/platenio/hugo-toroidal
+
+go 1.17

--- a/layouts/partials/toroidal/member-entry.html
+++ b/layouts/partials/toroidal/member-entry.html
@@ -1,0 +1,6 @@
+<li class="toroidal-member-entry">
+  <a href="{{ .Params.homepage }}">{{ .Params.name }}</a>
+  {{- with .Params.description -}}
+  : <span>{{ . }}</span>
+  {{- end -}}
+</li>

--- a/layouts/toroidal/list.html
+++ b/layouts/toroidal/list.html
@@ -1,0 +1,18 @@
+{{ define "main" }}
+{{ $vars := newScratch }}
+{{ with .Site.Params.Toroidal.WebringName }}
+  {{ $vars.Set "webringName" (printf " %s " .)}}
+{{ else }}
+  {{ $vars.Set "webringName" ""}}
+{{ end }}
+<article class="toroidal">
+  <h2>Members of the {{ $vars.Get "webringName" }} Webring</h2>
+  <ul class="toroidal-member-list">
+    {{ range .Paginator.Pages }}
+    {{ partial "toroidal/member-entry" . }}
+    {{ end }}
+  </ul>
+  {{ template "_internal/pagination.html" . }}
+  <iframe src="{{ relref . "/toroidal/first-member" }}"></iframe>
+</article>
+{{ end }}

--- a/layouts/toroidal/single.html
+++ b/layouts/toroidal/single.html
@@ -1,0 +1,52 @@
+{{/*
+  Hugo sorts pages by weight in reverse,
+  so lower weights are "next" and higher weights are "prev"
+
+  For this reason, we invert our logic for the webring linking.
+*/}}
+{{- $vars := newScratch -}}
+{{/* Grab the list of member pages; these are already sorted by weight */}}
+{{- $toroidalPages := where .Site.Pages "Section" "toroidal"}}
+{{- $toroidalPages = where $toroidalPages "Params.homepage" "!=" nil -}}
+{{/* Set the name string for the menu label*/}}
+{{- with .Site.Params.Toroidal.WebringName -}}
+  {{- $vars.Set "webringName" (printf "%s " .) -}}
+{{- else -}}
+  {{- $vars.Set "webringName" "" -}}
+{{- end -}}
+{{/*
+  Get the previous page ("NextInSection" according to Hugo;
+  if none, get the *last* page in the section.
+*/}}
+{{- with .NextInSection -}}
+  {{- $vars.Set "previous" .Params.homepage -}}
+{{- else -}}
+  {{- range (last 1 $toroidalPages) -}}
+    {{- $vars.Set "previous" .Params.homepage -}}
+  {{- end -}}
+{{- end -}}
+{{/*
+  Get the next page ("PrevInSection" according to Hugo;
+  if none, get the *first* page in the section.
+*/}}
+{{- with .PrevInSection -}}
+  {{- $vars.Set "next" .Params.homepage -}}
+{{- else -}}
+  {{- range (first 1 $toroidalPages) -}}
+    {{- $vars.Set "next" .Params.homepage -}}
+  {{- end -}}
+{{- end -}}
+<nav aria-labelledby="toroidal-menu-label">
+  <h2 id="toroidal-menu-label">{{ $vars.Get "webringName" }}Webring</h2>
+  <ul role="menu" id="toroidal-menu" aria-label="{{ $vars.Get "webringName" }}Webring">
+    <li role="none">
+      <a role="menuitem" aria-haspopup="false" href="{{ $vars.Get "previous" }}">Previous</a>
+    </li>
+    <li role="none">
+      <a role="menuitem" aria-haspopup="false" href="{{ ref . "/toroidal"}}">Member List</a>
+    </li>
+    <li role="none">
+      <a role="menuitem" aria-haspopup="false" href="{{ $vars.Get "next" }}">Next</a>
+    </li>
+  </ul>
+</nav>

--- a/theme.yaml
+++ b/theme.yaml
@@ -1,0 +1,11 @@
+name: toroidal
+license: MIT
+licenselink: 'https://github.com/platenio/hugo-toroidal/blob/master/LICENSE'
+description: 'Tooling for hosting your own webring using a hugo site/repo as the source of truth/host.'
+homepage: 'http://platenio.github.io/hugo-toroidal'
+tags: []
+features: []
+min_version: 0.1.0
+author:
+  name: Michael T Lombardi
+  homepage: 'https://twitter.com/trebuchetops'


### PR DESCRIPTION
This first pass at implementation creates both list and single view layouts for markdown files in the content/toroidal folder of a hugo site. The list view will display all of the members of the webring while the single view generates the navigation menus for member sites to include as iframes in their own sites.

This implementation includes zero theming or ease of use helpers; it merely defines a structure for turning member markdown pages into navigation menus for inclusion in member sites and provides a webring member site list for convenience.

This implementation includes a first pass at documentation.

Future work will be needed to improve the adoption and usage UX for the module in order for non-programmers to use it effectively.