### PR TITLE
(GH-7) Add option to enable link to random member

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ We'll update this section when that's ready!
 
 ## Configuring Your Webring
 
-Right now there's only one configuration item for this module and it's optional.
+Right now there's only a few configuration items for this module and they're optional.
+
+### Webring Name
 
 If you'd like to name your Webring, edit your site config:
 
@@ -54,6 +56,30 @@ params:
 The above example will change the header for your site member list to `Members of the FooBar Webring` and the generated webring navigation label to `FooBar Webring`.
 
 If left unset, the header for your site member list will read `Members of the Webring` and the generated webring navigation label will read `Webring`.
+
+### Random Member Link
+
+By default, the iframes for your webring include the name of the webring and then a nav list enabling users to go to the previous member of the webring,
+the list of all webring members, or the next member of the webring.
+
+With the `RandomMemberLink` configuration option, you can enable users to click a link to navigate to the homepage of a random member of the webring.
+
+```yaml
+#config.yaml
+params:
+  Toroidal:
+    RandomMemberLink: true
+```
+
+```toml
+#config.toml
+[params]
+  [params.Toroidal]
+  WebringName = true
+```
+
+Specifying the value for this configuration item as `false` is the same as not specifying it.
+You must opt in by setting this configuration item to `true` to enable the random member link.
 
 ## Adding Members
 

--- a/layouts/toroidal/single.html
+++ b/layouts/toroidal/single.html
@@ -36,7 +36,31 @@
     {{- $vars.Set "next" .Params.homepage -}}
   {{- end -}}
 {{- end -}}
+{{/*
+  Get the list of member pages and create the javascript for selecting a random page.
+*/}}
+{{- if .Site.Params.Toroidal.RandomMemberLink -}}
+  {{- range (first 1 $toroidalPages) -}}
+    {{- $vars.Set "memberPages" (slice .Params.homepage) -}}
+  {{- end -}}
+  {{- range $toroidalPages -}}
+    {{- if not (in ($vars.Get "memberPages") .Params.homepage) -}}
+      {{- $vars.Set "memberPages" (($vars.Get "memberPages") | append .Params.homepage) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
 <nav aria-labelledby="toroidal-menu-label">
+  {{- if .Site.Params.Toroidal.RandomMemberLink -}}
+  <script type="text/javascript">
+    var memberPages = {{ ($vars.Get "memberPages" | jsonify | safeJS) }};
+    function getRandomMemberPage() {
+      return memberPages[Math.floor(Math.random() * memberPages.length)];
+    };
+    function goToRandomMemberPage() {
+      window.open(getRandomMemberPage(), "_blank")
+    }
+  </script>
+  {{- end -}}
   <h2 id="toroidal-menu-label">{{ $vars.Get "webringName" }}Webring</h2>
   <ul role="menu" id="toroidal-menu" aria-label="{{ $vars.Get "webringName" }}Webring">
     <li role="none">
@@ -45,6 +69,11 @@
     <li role="none">
       <a role="menuitem" aria-haspopup="false" target="_parent" href="{{ ref . "/toroidal"}}">Member List</a>
     </li>
+    {{- if .Site.Params.Toroidal.RandomMemberLink -}}
+    <li role="none">
+      <a role="menuitem" aria-haspopup="false" target="_parent" onclick="this.href=getRandomMemberPage()" href="Random Member">Random</a>
+    </li>
+    {{- end -}}
     <li role="none">
       <a role="menuitem" aria-haspopup="false" target="_parent" href="{{ $vars.Get "next" }}">Next</a>
     </li>


### PR DESCRIPTION
Prior to this PR, the nav for a toroidal iframe only allowed users to navigate to the previous/next member in the webring or to the list of all members on the toroidal host.

This PR adds a new configuration option, **RandomMemberLink** and modifies the implementation of the single template (which is what the members will get from their iframe on their own site) to select a random member from the list of valid members of the webring on click.

Each click is wholly random, so a user can ctrl click the link 2-3 times to load different sites.

Resolves #7.