### PR TITLE
(MAINT) Fix SCSS bug breaking builds

### DIFF
--- a/layouts/partials/toroidal/member-entry-page.html
+++ b/layouts/partials/toroidal/member-entry-page.html
@@ -29,7 +29,7 @@
 <nav aria-labelledby="{{ $labelId }}"
      id="{{ $navId }}">
   {{- with $styles }}
-  {{ partial "toroidal/utils/getStylesLink" . }}
+  {{ . }}
   {{- end -}}
   {{- if $displayRandom }}
   <script type="text/javascript">

--- a/layouts/partials/toroidal/utils/getPageInfo.html
+++ b/layouts/partials/toroidal/utils/getPageInfo.html
@@ -9,7 +9,7 @@
 {{- $vars.Set "webringApiUrl" (ref . (dict "path" "/toroidal/admin.md" "outputFormat" "toroidal")) -}}
 {{- $vars.Set "prevHref" (partial "toroidal/utils/getPrevHref" (dict "context" . "toroidalPages" $toroidalPages)) -}}
 {{- $vars.Set "nextHref" (partial "toroidal/utils/getNextHref" (dict "context" . "toroidalPages" $toroidalPages)) -}}
-{{- $vars.Set "styles" (partial "toroidal/utils/getStyles" .) -}}
+{{- $vars.Set "styles" (partial "toroidal/utils/getStylesLink" .) -}}
 {{- $vars.Set "hideHeader" .Params.Toroidal.NoHeader -}}
 {{- $vars.Set "displayRandom" .Site.Params.toroidal.RandomMemberLink -}}
 {{- $vars.Set "memberPages" (partial "toroidal/utils/getMemberPages" .) -}}

--- a/layouts/partials/toroidal/utils/getStyles.html
+++ b/layouts/partials/toroidal/utils/getStyles.html
@@ -1,2 +1,0 @@
-{{- $styles := resources.Get "toroidal/toroidal.scss" | resources.ExecuteAsTemplate "toroidal/toroidal.scss" . | resources.ToCSS | resources.Minify | resources.Fingerprint -}}
-{{- return $styles -}}

--- a/layouts/partials/toroidal/utils/getStylesFingerprint.html
+++ b/layouts/partials/toroidal/utils/getStylesFingerprint.html
@@ -1,0 +1,2 @@
+{{- $stylesFingerprint := resources.Get "toroidal/toroidal.scss" | resources.ExecuteAsTemplate "toroidal/toroidal.scss" . | resources.ToCSS | resources.Minify | resources.Fingerprint -}}
+{{- return $stylesFingerprint -}}

--- a/layouts/partials/toroidal/utils/getStylesLink.html
+++ b/layouts/partials/toroidal/utils/getStylesLink.html
@@ -1,5 +1,5 @@
-{{- $styles := partial "toroidal/utils/getStyles" . -}}
-<link rel="stylesheet" href="{{ $styles.RelPermalink }}" {{ template "integrity" $styles }}>
+{{- $stylesFingerprint := partial "toroidal/utils/getStylesFingerprint" . -}}
+<link rel="stylesheet" href="{{ $stylesFingerprint.RelPermalink }}" {{ template "integrity" $stylesFingerprint }}>
 {{- define "integrity" -}}
   {{- if (urls.Parse .Permalink).Host -}}
     integrity="{{ .Data.Integrity }}" crossorigin="anonymous"


### PR DESCRIPTION
Prior to this commit, every other build of a site using this module would fail, but `hugo serve` commands would run without visible errors. The error was:

> Error building site: EXECUTE-AS-TEMPLATE: failed to transform
> "toroidal/toroidal.scss" (`text/x-scss`): template:
> `toroidal/toroidal.scss:3:39`: executing "toroidal/toroidal.scss" at
> `<.Site.Params.Toroidal.Theme>`: can't evaluate field `Site` in type
> `*resources.resourceAdapter`

The root issue for this error was the way the `member-entry-page` html partial was implemented after the last update, using `with $styles` where `$styles` was the _fingerprint_ of the processed SCSS file, to pass the context of that variable to the `getStylesLink` partial.

Doing so caused an error because `getStylesLink` expects to have a `Page` context to use when (re)retreiving the style fingerprint.

This commit:

1. Refactors the `utils/getPageInfo` partial to call the `getStylesLink` partial directly instead of `getStyles`, storing the link in scratch.
2. Refactors the implementation in the `member-entry-page` partial to instead use go templating to add the style link itself into the page.
3. Renames the `getStyles` partial to `getStylesFingerprint` and updates the reference to it in `getStylesLink`.

In the future, it might be worth collapsing `getStylesFingerprint` into `getStylesLink` directly, but for now we'll leave it in place.

I do not have a *firm* hypothesis as to why the build behavior was only intermittently failing during builds; the builds alternated between success and failure, one after the other but `hugo serve` always worked.

Here's what I *think* was happening:

> Even though it was raising an error during the build, the scss _did_ get generated and laid down in the cache - so the next time it goes to build, because it didn't _finish_ it doesn't _clear_ the cache - and then it skips processing that bit because it seems cached and everything is fine.
>
> But when I _rebuild_ after a successful build, it clears those cached files and tries to do it over, fails again. Which is why it's always `fail -> success -> fail -> success -> fail -> success`
>
> I don't really understand why _serve_ always works, except that maybe it has a retry mechanism.

With this bug resolved, work on the project can continue.