### PR TITLE
(GH-4) Support multiple webrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ The above example will change the header for your site member list to `Members o
 
 If left unset, the header for your site member list will read `Members of the Webring` and the generated webring navigation label will read `Webring`.
 
+You can also add an `_index.md` file to the section of your site which hosts
+your webring. If you do, the frontmatter for that file determines your webring
+name:
+
+- If the `name` parameter is set, that will be the name of your webring.
+- If the `name` parameter is _not_ set, the name of your webring will be the
+  title of that page (automatically determined by hugo unless you set the
+  `title` parameter).
+
+For more information on webring index files, see
+[Webring Index files](#webring-index-files).
+
 ### Random Member Link
 
 By default, the iframes for your webring include the name of the webring and then a nav list enabling users to go to the previous member of the webring,
@@ -113,6 +125,46 @@ unfortunately, you need to [check out the source][source-variables] to see what 
 If you have any ideas for theming or run into anything you'd like us to make more extensible,
 please [file an issue][file-an-issue].
 
+## Webring Index Files
+
+If you create an `_index.md` file in the base of the `toroidal` folder of your
+site, you can have a little more control over how your webring behaves. Any
+configuration setting in an index file takes precedence over the site's
+configuration.
+
+In the frontmatter of a webring index, you can set:
+
+- `title`:
+- `name`:
+- `description`:
+
+If you are using the index file from any folder other than `content/toroidal`
+in your site, you **must** set the `type` parameter to `toroidal` for it to be
+recognized as a webring index.
+
+### Example Webring Index
+
+This index is located at `content/friends/_index.md`.
+
+Frontmatter:
+
+```yaml
+title: The Fast Friends
+name: Fast Friends
+description: |
+  A webring of collaborators; artists, writers, developers, and designers who
+  work together and separately, supporting one another.
+type: toroidal
+```
+
+In this example, the webring name is `Fast Friends`. If you comment out the
+`name` parameter, the webring name would become `The Fast Friends`. With both
+parameters commented out, the webring name would become `Friends`, (the
+automatic title Hugo gives the page if none is specified).
+
+The `type` parameter is required because this page is not in the default folder
+for toroidal webrings (`content/toroidal`).
+
 ## Adding Members
 
 You can add new member sites to your webring by adding a markdown file in your `content/toroidal` folder.
@@ -163,6 +215,18 @@ and then review the code snippets and choose whether they want to copy the liter
 use an iframe. This view also shows them their currently configured homepage (which other members
 will navigate to for their entry in the webring) and the link to where the member can edit the
 markdown source file for their member entry.
+
+## Multiple Webrings
+
+In addition to hosting a single webring, you can host any number of webrings.
+Any webring not hosted in the root of the `content/toroidal` folder **must**
+include an `_index.md` file with the `type` parameter set to `toroidal` in its
+frontmatter. For more information, see
+[Webring Index Files](#webring-index-files).
+
+Other than the requirement of the index file, additional webrings work and can
+be configured like a top-level webring, including
+[administration][admin-page].
 
 ## Adding the webring navigation to your member site
 

--- a/layouts/partials/toroidal/admin.html
+++ b/layouts/partials/toroidal/admin.html
@@ -1,15 +1,8 @@
-{{- $vars := newScratch -}}
-{{- with .Site.Params.Toroidal.WebringName -}}
-  {{- $vars.Set "webringName" (printf " %s " .) -}}
-{{- else -}}
-  {{- $vars.Set "webringName" "" -}}
-{{- end -}}
-{{/* Grab the list of member pages; these are already sorted by weight */}}
-{{- $toroidalPages := where .Site.Pages "Section" "toroidal" -}}
-{{- $toroidalPages = where $toroidalPages "Params.homepage" "!=" nil -}}
+{{- $webringName := partial "toroidal/utils/getWebringName" . -}}
+{{- $webringMemberPages := where .CurrentSection.RegularPages "Params.homepage" "!=" nil -}}
 <article class="toroidal">
   <header>
-    <h1>{{ $vars.Get "webringName" }} Administration</h1>
+    <h1>{{ $webringName }} Administration</h1>
     {{ partial "toroidal/utils/getStylesLink" . }}
     <details>
       <summary>About member administation</summary>
@@ -56,7 +49,7 @@
       </p>
     </details>
   </header>
-  {{- range $toroidalPages -}}
+  {{- range $webringMemberPages -}}
   {{ partial "toroidal/member-entry-admin" . }}
   {{- end -}}
   <footer>

--- a/layouts/partials/toroidal/item.toroidal.json
+++ b/layouts/partials/toroidal/item.toroidal.json
@@ -1,19 +1,25 @@
 {{/*
-  Expects a dict with `context` for the current page
-  and `inList` for whether or not this should be
-  included in a list or is a standalone entry.
+  Expects a dict with `context` for the current page and `inList` for whether
+  or not this should be included in a list or is a standalone entry. This
+  partial returns the JSON representation of the metadata for the context of
+  this member page with the following properties:
+
+  - `name`: The name of this member
+  - `home`: The URL to this member's homepage
+  - `prev`: The URL to the previous webring member's homepage
+  - `next`: The URL to the next webring member's homepage
 */}}
 {{- $vars := partial "toroidal/utils/getPageInfo" .context -}}
 {{- if .inList }}{
         "name": "{{ .context.Params.name }}",
         "home": "{{ .context.Params.homepage }}",
-        "prev": "{{ $vars.Get "prevHref"}}",
+        "prev": "{{ $vars.Get "prevHref" }}",
         "next": "{{ $vars.Get "nextHref" }}"
       }
 {{- else }}{
     "name": "{{ .context.Params.name }}",
     "home": "{{ .context.Params.homepage }}",
-    "prev": "{{ $vars.Get "prevHref"}}",
+    "prev": "{{ $vars.Get "prevHref" }}",
     "next": "{{ $vars.Get "nextHref" }}"
   }
 {{- end -}}

--- a/layouts/partials/toroidal/member-entry-page.html
+++ b/layouts/partials/toroidal/member-entry-page.html
@@ -1,8 +1,8 @@
 {{/*
-  This partial returns the nav list for a member of a webring.
-  It expects to receive an instance of scratch with the params
-  already set; the only logic this performs is to arrange and
-  format the information. All retrieval must be done first.
+  This partial returns the nav list for a member of a webring. It expects to
+  receive an instance of scratch with the params already set; the only logic
+  this performs is to arrange and format the information. All retrieval must
+  be done first.
 */}}
 {{- $vars := . -}}
 {{- $webringName     := $vars.Get "webringName"    -}}
@@ -14,7 +14,7 @@
 {{- $styles          := $vars.Get "styles"         -}}
 {{- $hideHeader      := $vars.Get "hideHeader"     -}}
 {{- $displayRandom   := $vars.Get "displayRandom"  -}}
-{{- $memberPages     := $vars.Get "memberPages"    -}}
+{{- $memberPageLinks := $vars.Get "memberPageLinks" -}}
 {{- $forEmbedding    := $vars.Get "forEmbedding"   -}}
 {{- $displayComments := $vars.Get "displayComments" -}}
 {{/* Calculated properties */}}
@@ -47,7 +47,7 @@
     {{ "// webring host's API. For more info, see the comments"  | safeJS }}
     {{ "// on loadFromAdminApi() and window.onload. "            | safeJS }}
     {{ end -}}
-    var memberPages = {{ $memberPages | jsonify (dict "prefix" "    " "indent" "  ") | safeJS }}
+    var memberPages = {{ $memberPageLinks | jsonify (dict "prefix" "    " "indent" "  ") | safeJS }}
     
     {{ if $displayComments -}}
     {{ "// This function returns a random member page from the"  | safeJS }}

--- a/layouts/partials/toroidal/utils/getMemberPageLinks.html
+++ b/layouts/partials/toroidal/utils/getMemberPageLinks.html
@@ -1,19 +1,20 @@
 {{/*
   This partial expects to receive the context for a page whose type is toroidal
   and discovers all of the member sites in the same webring, returning their
-  contexts in a slice.
+  homepage URLs as a slice of strings.
 
   It does so by:
   
   1. Checking the page's parent for all the regular (i.e. non-section) pages
      which have configured their homepage to a non-empty string; any page
      without this set properly must be ignored so links don't break.
-  2. Looping over those discovered pages, appending their context to the slice.
+  2. Looping over those discovered pages, appending their defined home page
+     URL to the slice.
   3. Returning the slice.
 */}}
 {{- $toroidalPages := where .Parent.RegularPages "Params.homepage" "!=" nil -}}
-{{- $memberPages := slice -}}
+{{- $memberPageLinks := slice -}}
 {{- range $toroidalPages -}}
-    {{- $memberPages = $memberPages | append . -}}
+    {{- $memberPageLinks = $memberPageLinks | append .Params.homepage -}}
 {{- end -}}
-{{- return $memberPages -}}
+{{- return $memberPageLinks -}}

--- a/layouts/partials/toroidal/utils/getNextHref.html
+++ b/layouts/partials/toroidal/utils/getNextHref.html
@@ -1,13 +1,22 @@
 {{/*
-  Expects a dict with `context` for the current page
-  and `toroidalPages` for the list of webring member
-  entries in the site.
+  Expects a dict with `context` for the current page and `memberPages` for the
+  list of webring member entries in the site. It determines and returns the
+  link for the next page in the webring by:
+
+  1. Checking for the previous page in the section; because the weighting in
+     hugo orders things in reverse from the naive expectation of a user (i.e.
+     the lower weight is "next" instead of "previous"), we have to invert the
+     logic even though we want the _next_ highest page weight from the list.
+  2. If the href can't be determined from the previous step, filter the list
+     of member pages to exclude this page and set the href to the home page
+     url of the first item in that filtered slice.
 */}}
 {{- $nextHref := "" -}}
 {{- with .context.PrevInSection -}}
   {{- $nextHref = .Params.homepage -}}
 {{- end -}}
 {{- if not $nextHref -}}
-  {{- $nextHref = (index .toroidalPages 0).Params.homepage -}}
+  {{- $validMembers := where .memberPages "Params.homepage" "!=" .context.Params.homepage -}}
+  {{- $nextHref = (index $validMembers 0).Params.homepage -}}
 {{- end -}}
 {{- return $nextHref -}}

--- a/layouts/partials/toroidal/utils/getPageInfo.html
+++ b/layouts/partials/toroidal/utils/getPageInfo.html
@@ -1,19 +1,41 @@
+{{- /*
+  This partial expects to receive the context for a page whose type is toroidal
+  and returns a scratch with the following values:
+
+  - `webringName`: The calculated name of the webring this page belongs to.
+  - `memberListHref`: The URL to the page on the host site which lists all of
+     the members of the webring and where the `Member List` link in the
+     generated nav takes a user.
+  - `memberPages`: The list of page contexts for this webring's members.
+  - `memberPageLinks`: The list of home page URLs for this webring's members.
+  - `webringApiUrl`: The URL to the JSON blob on the host site which includes
+     all of the information needed to understand/interact with this webring.
+  - `prevHref`: The URL to the previous member's homepage in this webring.
+  - `nextHref`: The URL to the next member's homepage in this webring.
+  - `styles`: The link element for the calculated SCSS for this member page.
+  - `hideHeader`: Whether or not this member page should display the webring's
+    name as a header tag; this must be explicitly set by the user in the page
+    frontmatter or the header will be displayed.
+  - `displayRandom`: Whether or not this member page should include the random
+     member link in the navigation; this must be explicitly set by the site's
+     owner in the site configuration or this will not be displayed.
+  - `memberName`: The name of this member of the webring.
+*/ -}}
 {{- $vars := newScratch -}}
 
 {{/* Grab the list of member pages; these are already sorted by weight */}}
-{{- $toroidalPages := where .Site.Pages "Section" "toroidal"}}
-{{- $toroidalPages = where $toroidalPages "Params.homepage" "!=" nil -}}
+{{- $memberPages := partial "toroidal/utils/getMemberPages" . -}}
 {{/* Set the variables for the iframe */}}
 {{- $vars.Set "webringName" (partial "toroidal/utils/getWebringName" .) -}}
 {{- $vars.Set "memberListHref" (ref . "/toroidal") -}}
+{{- $vars.Set "memberPages" $memberPages -}}
+{{- $vars.Set "memberPageLinks" (partial "toroidal/utils/getMemberPageLinks" .) -}}
 {{- $vars.Set "webringApiUrl" (ref . (dict "path" "/toroidal/admin.md" "outputFormat" "toroidal")) -}}
-{{- $vars.Set "prevHref" (partial "toroidal/utils/getPrevHref" (dict "context" . "toroidalPages" $toroidalPages)) -}}
-{{- $vars.Set "nextHref" (partial "toroidal/utils/getNextHref" (dict "context" . "toroidalPages" $toroidalPages)) -}}
+{{- $vars.Set "prevHref" (partial "toroidal/utils/getPrevHref" (dict "context" . "memberPages" $memberPages)) -}}
+{{- $vars.Set "nextHref" (partial "toroidal/utils/getNextHref" (dict "context" . "memberPages" $memberPages)) -}}
 {{- $vars.Set "styles" (partial "toroidal/utils/getStylesLink" .) -}}
 {{- $vars.Set "hideHeader" .Params.Toroidal.NoHeader -}}
 {{- $vars.Set "displayRandom" .Site.Params.toroidal.RandomMemberLink -}}
-{{- $vars.Set "memberPages" (partial "toroidal/utils/getMemberPages" .) -}}
-{{- $vars.Set "toroidalPages" $toroidalPages }}
 {{- $vars.Set "memberName" .Params.name -}}
 
 {{- return $vars -}}

--- a/layouts/partials/toroidal/utils/getPrevHref.html
+++ b/layouts/partials/toroidal/utils/getPrevHref.html
@@ -1,13 +1,22 @@
 {{/*
-  Expects a dict with `context` for the current page
-  and `toroidalPages` for the list of webring member
-  entries in the site.
+  Expects a dict with `context` for the current page and `memberPages` for the
+  list of webring member entries in the site. It determines and returns the
+  link for the previous page in the webring by:
+
+  1. Checking for the next page in the section; because the weighting in hugo
+     orders things in reverse from the naive expectation of a user (i.e. the
+     higher weight is "previous" instead of "next"), we have to invert the
+     logic even though we want the _previous_ page weight from the list.
+  2. If the href can't be determined from the previous step, filter the list
+     of member pages to exclude this page and set the href to the home page
+     url of the last item in that filtered slice.
 */}}
 {{- $prevHref := "" -}}
 {{- with .context.NextInSection -}}
   {{- $prevHref = .Params.homepage -}}
 {{- end -}}
 {{- if not $prevHref -}}
-  {{- $prevHref = (index .toroidalPages 0).Params.homepage -}}
+  {{- $validMembers := where .memberPages "Params.homepage" "!=" .context.Params.homepage -}}
+  {{- $prevHref = (index (last 1 $validMembers) 0).Params.homepage -}}
 {{- end -}}
 {{- return $prevHref -}}

--- a/layouts/partials/toroidal/utils/getWebringName.html
+++ b/layouts/partials/toroidal/utils/getWebringName.html
@@ -1,5 +1,47 @@
-{{ $webringName := "Webring" }}
+{{- /*
+  This partial expects to receive the context for a page whose type is toroidal
+  and will resolve the correct name for that page's webring by:
+
+  1. Looking for the index file for the section - for any webrings not defined
+     at the root of a top-level toroidal section, they _require_ an `_index.md`
+     file for the theme to recognize them at all; they are optional for any
+     webrings defined in top-level sections.
+  2. If the index file has the toroidal type, it will inspect that page:
+     - if the `name` parameter is set, it will use that value
+     - if the `name` parameter is not set, it will use the page's Title
+  3. If the index file is not toroidal or no index file is found, it will fall
+     back on the site's webring name. The site webring name is defined as:
+     - The value of the site parameter `.Toroidal.WebringName`, if set.
+     - "Webring" if the parameter is not set.
+*/ -}}
+{{- $webringName := "" -}}
+{{- $ringIndex := .GetPage "_index.md" }}
+{{- $siteWebringName := "" -}}
 {{- with .Site.Params.Toroidal.WebringName -}}
-  {{- $webringName = . -}}
+  {{- $siteWebringName = . -}}
+{{- else -}}
+  {{- $siteWebringName = "Webring" -}}
 {{- end -}}
+
+{{- with $ringIndex -}}
+  {{- /*
+    For some reason, `GetPage` on files in a top-level toroidal section without
+    an `_index.md` file resolves to the `_index.md` of the *site* insteadd of
+    nil; so here we need to check and ensure that the type is toroidal to
+    ensure that we don't accidentally name the webring after the site.
+  */ -}}
+  {{- if eq $ringIndex.Type "toroidal" -}}
+    {{- with .Params.name -}}
+      {{- $webringName = . -}}
+    {{- else -}}
+      {{- $webringName = .Title -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{/*
+  We need to handle when the name is note explicitly set/is an empty string; we
+  can fall back using the site's webring name.
+*/}}
+{{- $webringName = default $siteWebringName $webringName -}}
+
 {{- return $webringName -}}

--- a/layouts/partials/toroidal/utils/getWebrings.html
+++ b/layouts/partials/toroidal/utils/getWebrings.html
@@ -1,0 +1,23 @@
+{{/*
+  This partial looks over the entire site for toroidal sections and then adds
+  each discovered section with 1+ defined/functional member to the list of
+  webrings. For each of those sections it also looks for child sections with
+  members, adding those too.
+
+  In this implementation, only one level of nesting is supported. It is not
+  recursive. It only looks inside top-level sections which are defined with
+  the toroidal type.
+*/}}
+{{- $webrings := slice -}}
+{{- $sectionsToSearch := where $.Site.Sections "Type" "toroidal" -}}
+{{- range where .Site.Sections "Type" "toroidal" -}}
+  {{- if len (where .RegularPages "Params.homepage" "!=" nil) -}}
+    {{- $webrings = $webrings | append . -}}
+  {{- end -}}
+  {{- range .Sections -}}
+    {{- if len (where .RegularPages "Params.homepage" "!=" nil) -}}
+      {{- $webrings = $webrings | append . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- return $webrings -}}

--- a/layouts/toroidal/admin/single.toroidal.json
+++ b/layouts/toroidal/admin/single.toroidal.json
@@ -1,11 +1,26 @@
+{{- /*
+  This partial expects to receive the context for a page whose type is
+  `toroidal` or `toroidal/admin`. It writes a JSON object which has the
+  following properties:
+
+  - `webringName`: The name of the webring this page belongs to.
+  - `webringList`: The URL to the page on the host site which lists all of the
+     members of the webring and where the `Member List` link in the generated
+     nav takes a user.
+  - `members`: An array of JSON objects with the following properties:
+    - `name`: The name of this member
+    - `home`: The URL to this member's homepage
+    - `prev`: The URL to the previous webring member's homepage
+    - `next`: The URL to the next webring member's homepage
+*/ -}}
 {{ define "response" -}}
-{{- $toroidalPages := where .Site.Pages "Section" "toroidal" -}}
-{{- $toroidalPages = where $toroidalPages "Params.homepage" "!=" nil -}}
+{{- $webringName := partial "toroidal/utils/getWebringName" . -}}
+{{- $webringMemberPages := where .CurrentSection.RegularPages "Params.homepage" "!=" nil -}}
   {
-    "webringName": "{{ partial "toroidal/utils/getWebringName" .}}",
-    "webringList": "{{ ref . "/toroidal" }}",
+    "webringName": "{{ $webringName }}",
+    "webringList": "{{ .CurrentSection.Permalink }}",
     "members": [
-      {{- range $index, $page := $toroidalPages -}}
+      {{- range $index, $page := $webringMemberPages -}}
       {{- if $index }},{{ end }}
       {{ partial "toroidal/item.toroidal.json" (dict "context" $page "inList" true) -}}
       {{- end }}

--- a/layouts/toroidal/list.html
+++ b/layouts/toroidal/list.html
@@ -1,12 +1,16 @@
+{{- /*
+  This layout defines the member list page for a toroidal section. It inserts:
+
+  - An article with the `toroidal` class, containing:
+    - an `h2` header explaining the page's purpose
+    - an unordered list with the `toroidal-member-list` class containing an
+      entry for each member of this webring with their homepage set to a URL;
+      this list is paginated.
+*/ -}}
 {{- define "main" -}}
-{{- $vars := newScratch -}}
-{{- with .Site.Params.Toroidal.WebringName -}}
-  {{- $vars.Set "webringName" . -}}
-{{- else -}}
-  {{- $vars.Set "webringName" "Webring" -}}
-{{- end -}}
+{{- $webringName := partial "toroidal/utils/getWebringName" . -}}
 <article class="toroidal">
-  <h2>Members of the {{ $vars.Get "webringName" }}</h2>
+  <h2>Members of the {{ $webringName }}</h2>
   <ul class="toroidal-member-list">
     {{- range where .Paginator.Pages "Params.homepage" "!=" nil -}}
     {{ partial "toroidal/member-entry-list" . }}


### PR DESCRIPTION
Prior to this commit, the module could only host a single webring and was hard-coded to only respect webrings defined in the `content/toroidal` folder.

This commit enhances the implementation to enable site maintainers to host a toroidal webring in any folder on their site, including in subfolders of `content/toroidal`, so long as each folder has an `_index.md` file with `type` set to `toroidal` in the file's frontmatter.

This also required overhauling the partials:

- `getMemberPages` was renamed to `getMemberPageLinks` to return the URLs to the homepages for every member of the current context's webring and modified to use `.Parent.RegularPages` instead of only searching for the list of pages in the `toroidal` section at the top of the site.
- `getMemberPages` was reimplemented from the same definition but now returns the _context_ for those pages instead of their home page URLs.
- `getNextHref` and `getPrevHref` were updated to correctly handle when there is no previous/next entry in their section, using the first and last items in the list of member pages returned by `getMemberPages` (excluding themself) respectively.
- `getPageInfo` now uses `getMemberPages` instead of finding the list of pages in the `content/toroidal` section and exposes `memberPages` as a variable instead of `toroidalPages`.
- `getWebringName` has been updated to handle using `_index.md` to define a webring, favoring settings in that file over the site.
- `getWebrings` is unused but provides a way to check a site for any/all defined webrings.

The `toroidal/list` layout was updated to use `getWebringName` instead of reimplementing the functionality in itself.

The `toroidal/admin/single.toroidal.json` layout was updated to retrieve member pages from the current section instead of hard-coding a retrieval from the top level toroidal section.

Finally, the readme was updated to document this functionality.

Resolves #4 