### PR TITLE
(MAINT) Move comments into define blocks

### DIFF
--- a/layouts/toroidal/admin/single.toroidal.json
+++ b/layouts/toroidal/admin/single.toroidal.json
@@ -1,3 +1,4 @@
+{{ define "response" -}}
 {{- /*
   This partial expects to receive the context for a page whose type is
   `toroidal` or `toroidal/admin`. It writes a JSON object which has the
@@ -13,7 +14,6 @@
     - `prev`: The URL to the previous webring member's homepage
     - `next`: The URL to the next webring member's homepage
 */ -}}
-{{ define "response" -}}
 {{- $webringName := partial "toroidal/utils/getWebringName" . -}}
 {{- $webringMemberPages := where .CurrentSection.RegularPages "Params.homepage" "!=" nil -}}
   {

--- a/layouts/toroidal/list.html
+++ b/layouts/toroidal/list.html
@@ -1,3 +1,4 @@
+{{- define "main" -}}
 {{- /*
   This layout defines the member list page for a toroidal section. It inserts:
 
@@ -7,7 +8,6 @@
       entry for each member of this webring with their homepage set to a URL;
       this list is paginated.
 */ -}}
-{{- define "main" -}}
 {{- $webringName := partial "toroidal/utils/getWebringName" . -}}
 <article class="toroidal">
   <h2>Members of the {{ $webringName }}</h2>


### PR DESCRIPTION
Prior to this commit, the `toroidal/list.html` and the `toroidal/admin/single.toroidal.json` layout files did not render.

Investigation showed that the new explanatory comments placed before the define block opened were the cause; this commit moves those comments inside the blocks to enable them to render correctly.